### PR TITLE
PODS-8597: changed event to have 0 members for testing display event …

### DIFF
--- a/conf/resources/data/api1834/24000041IN.json
+++ b/conf/resources/data/api1834/24000041IN.json
@@ -94,7 +94,7 @@
     },
     "event8": {
       "recordVersion": "004",
-      "numberOfMembers": 1500
+      "numberOfMembers": 0
     },
     "event8A": {
       "recordVersion": "003",


### PR DESCRIPTION
…summary logic

BE - https://github.com/hmrc/pension-scheme-event-reporting/pull/154
FE - https://github.com/hmrc/pension-scheme-event-reporting-frontend/pull/221